### PR TITLE
Fix linkage of `@llvm.global_ctors`

### DIFF
--- a/lib/libcxxffi.cpp
+++ b/lib/libcxxffi.cpp
@@ -1461,7 +1461,7 @@ JL_DLLEXPORT void cleanup_cpp_env(CxxInstance *Cxx, cppcall_state_t *state) {
     // GV.print(llvm::errs(), false);
     if (GV.hasPrivateLinkage() || GV.hasLinkOnceODRLinkage()) {
       GV.setLinkage(llvm::GlobalVariable::LinkOnceODRLinkage);
-    } else {
+    } else if (!GV.hasAppendingLinkage()) {
       GV.setLinkage(llvm::GlobalVariable::ExternalLinkage);
     }
   }


### PR DESCRIPTION
LLVM verifies its linkage, so probably it should not be external.
https://github.com/JuliaLang/llvm-project/blob/046f90173567535397c97b2d00406c93ee4bc890/llvm/lib/IR/Verifier.cpp#L717-L720