### PR TITLE
Avoid .text.startup

### DIFF
--- a/lib/libcxxffi.cpp
+++ b/lib/libcxxffi.cpp
@@ -1466,6 +1466,12 @@ JL_DLLEXPORT void cleanup_cpp_env(CxxInstance *Cxx, cppcall_state_t *state) {
     }
   }
 
+  for (auto &GF : jl_Module) {
+    if (GF.getSection() == ".text.startup") {
+      GF.setSection("");
+    }
+  }
+
   Function *F = Cxx->CGF->CurFn;
 
   // cleanup the environment

--- a/lib/libcxxffi.cpp
+++ b/lib/libcxxffi.cpp
@@ -1459,7 +1459,7 @@ JL_DLLEXPORT void cleanup_cpp_env(CxxInstance *Cxx, cppcall_state_t *state) {
 
   for (auto &GV : jl_Module.globals()) {
     // GV.print(llvm::errs(), false);
-    if (GV.hasPrivateLinkage() || GV.hasLinkOnceODRLinkage()) {
+    if (GV.hasLocalLinkage() || GV.hasLinkOnceODRLinkage()) {
       GV.setLinkage(llvm::GlobalVariable::LinkOnceODRLinkage);
     } else if (!GV.hasAppendingLinkage()) {
       GV.setLinkage(llvm::GlobalVariable::ExternalLinkage);


### PR DESCRIPTION
Another text section will trigger assertion failure, see https://github.com/JuliaLang/julia/blob/c609e9a22a17bef858559ca707cb985d770935aa/src/cgmemmgr.cpp#L861