### PR TITLE
Fix Duplicate definition of symbol std::__ioinit

### DIFF
--- a/lib/libcxxffi.cpp
+++ b/lib/libcxxffi.cpp
@@ -1459,7 +1459,7 @@ JL_DLLEXPORT void cleanup_cpp_env(CxxInstance *Cxx, cppcall_state_t *state) {
 
   for (auto &GV : jl_Module.globals()) {
     // GV.print(llvm::errs(), false);
-    if (GV.hasPrivateLinkage() || GV.hasLinkOnceODRLinkage()) {
+    if (GV.hasLocalLinkage() || GV.hasLinkOnceODRLinkage()) {
       GV.setLinkage(llvm::GlobalVariable::LinkOnceODRLinkage);
     } else {
       GV.setLinkage(llvm::GlobalVariable::ExternalLinkage);


### PR DESCRIPTION
Change the linkage of `std::__ioinit` will fix duplicate definition of it. However, after this, LLVM reports duplicate definition of `$.cppcall.__inits.0` which is a symbol generated by OrcJIT at https://github.com/JuliaLang/llvm-project/blob/99787ba4bcb3edc22f8608ce750613358953894d/llvm/lib/ExecutionEngine/Orc/Layer.cpp#L91.